### PR TITLE
Hide the scrollbars when not needed

### DIFF
--- a/css/Typeahead.css
+++ b/css/Typeahead.css
@@ -1,5 +1,5 @@
 .bootstrap-typeahead .dropdown-menu {
-  overflow: scroll;
+  overflow: auto;
 }
 .bootstrap-typeahead .dropdown-menu > li a:focus {
   outline: none;


### PR DESCRIPTION
Don't force the scrollbars to be displayed when the dropdown items fit into the view.
